### PR TITLE
Union tagging

### DIFF
--- a/FSharp.JSerde.Test/FSharp.JSerde.Test.fsproj
+++ b/FSharp.JSerde.Test/FSharp.JSerde.Test.fsproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.fs" />
-    <Compile Include="Library.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />

--- a/FSharp.JSerde.Test/FSharp.JSerde.Test.fsproj
+++ b/FSharp.JSerde.Test/FSharp.JSerde.Test.fsproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.fs" />
+    <Compile Include="Library.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />

--- a/FSharp.JSerde.Test/Library.fs
+++ b/FSharp.JSerde.Test/Library.fs
@@ -242,3 +242,11 @@ module Example =
     // printfn "parsed = %A" parsed
 
     Assert.AreEqual (value, parsed)
+
+  [<Test>]
+  let testUnionTagging () =
+    let json1 = Case2 "hello" |> JSerde.toJsonString JSerde.Config.Default
+    let json2 = Case2 "hello" |> JSerde.toJsonString { JSerde.Config.Default with UnionTagging = Some { Tag = "t"; Content = "c" } }
+    Assert.AreEqual (json1, "{\"Case2\":\"hello\"}")
+    Assert.AreEqual (json2, "{\"t\":\"Case2\",\"c\":\"hello\"}")
+

--- a/FSharp.JSerde.Test/Library.fs
+++ b/FSharp.JSerde.Test/Library.fs
@@ -21,6 +21,7 @@ and B = private {
 }
 
 type SingleCaseUnion = private SingleCaseUnion of int
+type InvalidSingleCaseUnion = CaseNameDifferentFromTypeName of int
 
 type Flags =
   | A = 0b001uy
@@ -128,6 +129,10 @@ let singleCaseUnion () =
   test
     (Map [SingleCaseUnion 1010, 3.21; SingleCaseUnion 2020, 6.54])
     (JsonValue.Record [| "1010", JsonValue.Float 3.21; "2020", JsonValue.Float 6.54 |])
+
+  test
+    (CaseNameDifferentFromTypeName 333)
+    (JsonValue.Record [| "CaseNameDifferentFromTypeName", JsonValue.Number (decimal 333) |])
 
 [<Test>]
 let guid () =

--- a/FSharp.JSerde.Test/Library.fs
+++ b/FSharp.JSerde.Test/Library.fs
@@ -168,7 +168,7 @@ let omitNoneFieldOfRecord() =
 [<Test>]
 let taggedUnion() =
   let test =
-    let cfg = { JSerde.Config.Default with Tag = Some { Tag = "t"; Content = "c" } }
+    let cfg = { JSerde.Config.Default with UnionTagging = Some { Tag = "t"; Content = "c" } }
     testBy cfg
 
   test Case1 (JsonValue.String "Case1")

--- a/FSharp.JSerde.Test/Library.fs
+++ b/FSharp.JSerde.Test/Library.fs
@@ -174,6 +174,19 @@ let taggedUnion() =
   test Case1 (JsonValue.String "Case1")
   test (Case2 123) (JsonValue.Record [| "t", JsonValue.String "Case2"; "c", JsonValue.Number (decimal 123) |])
 
+  test (Case3 ("hoge", 3.14))
+    (JsonValue.Record [|
+      "t", JsonValue.String "Case3"
+      "c", JsonValue.Array [| JsonValue.String "hoge"; JsonValue.Float 3.14 |] |])
+
+  test (Case4 { Foo = 123; Bar = "bar"; Buzz = None })
+    (JsonValue.Record [|
+      "t", JsonValue.String "Case4"
+      "c", JsonValue.Record [| "Foo", JsonValue.Number (decimal 123); "Bar", JsonValue.String "bar" |] |])
+
+  test (Case7 None) (JsonValue.Record [| "t", JsonValue.String "Case7"; "c", JsonValue.Null |])
+  test (Case7 (Some 10)) (JsonValue.Record [| "t", JsonValue.String "Case7"; "c", JsonValue.Number (decimal 10) |])
+
 
 [<Test>]
 let primitiveTypes () =

--- a/FSharp.JSerde.Test/Library.fs
+++ b/FSharp.JSerde.Test/Library.fs
@@ -166,6 +166,16 @@ let omitNoneFieldOfRecord() =
 
 
 [<Test>]
+let taggedUnion() =
+  let test =
+    let cfg = { JSerde.Config.Default with Tag = Some { Tag = "t"; Content = "c" } }
+    testBy cfg
+
+  test Case1 (JsonValue.String "Case1")
+  test (Case2 123) (JsonValue.Record [| "t", JsonValue.String "Case2"; "c", JsonValue.Number (decimal 123) |])
+
+
+[<Test>]
 let primitiveTypes () =
   test true  (JsonValue.Boolean true)
   test false (JsonValue.Boolean false)

--- a/FSharp.JSerde/CustomSerializer.fs
+++ b/FSharp.JSerde/CustomSerializer.fs
@@ -12,10 +12,14 @@ type Serializer (customs: ICustomSerializer seq) =
   let customs = customs |> Seq.map (fun item -> item.TargetType, item) |> readOnlyDict 
 
   member _.Serialize (obj: obj): JsonValue option =
-    let t = obj.GetType() in if t.IsGenericType then t.GetGenericTypeDefinition() else t
-    |> customs.TryGetValue
-    |> function (true, ser) -> Some (ser.Serialize obj) | _ -> None
+    if customs.Count = 0 then None else
+      let t = obj.GetType() in if t.IsGenericType then t.GetGenericTypeDefinition() else t
+      |> customs.TryGetValue
+      |> function (true, ser) -> Some (ser.Serialize obj) | _ -> None
 
   member _.Deserialize (ty: System.Type, json: JsonValue): obj option =
-    customs.TryGetValue ty
-    |> function (true, ser) -> Some (ser.Deserialize json) | _ -> None
+    if customs.Count = 0 then None else
+      customs.TryGetValue ty
+      |> function (true, ser) -> Some (ser.Deserialize json) | _ -> None
+
+  static member Empty = Serializer Seq.empty

--- a/FSharp.JSerde/DesUtil.fs
+++ b/FSharp.JSerde/DesUtil.fs
@@ -87,7 +87,7 @@ let classify (t: System.Type) =
   | _, Some def when def = typedefof<Map<_, _>> -> Map (t.GenericTypeArguments[0], t.GenericTypeArguments[1], createMap t)
   | t, _ when FSharpType.IsUnion (t, bindingFlags) ->
     match FSharpType.GetUnionCases (t, true) with
-    | [| case |] -> SingleCaseUnion (case.GetFields(), fun args -> FSharpValue.MakeUnion (case, args, bindingFlags))
+    | [| case |] when case.Name = t.Name -> SingleCaseUnion (case.GetFields(), fun args -> FSharpValue.MakeUnion (case, args, bindingFlags))
     | cases -> Union (cases, fun case args -> FSharpValue.MakeUnion (case, args, bindingFlags))
   | t, _ when FSharpType.IsRecord (t, bindingFlags) ->
     Record (FSharpType.GetRecordFields (t, bindingFlags), fun args -> FSharpValue.MakeRecord(t, args, true))

--- a/FSharp.JSerde/JSerde.fs
+++ b/FSharp.JSerde/JSerde.fs
@@ -16,11 +16,11 @@ type UnionTagging = {
 
 type Config = {
   Serializer: Serializer
-  Tag: UnionTagging option
+  UnionTagging: UnionTagging option
 } with
   static member Default =
     { Serializer = Serializer.Empty
-      Tag = None }
+      UnionTagging = None }
 
   static member FromCustomSerializers customs =
     { Config.Default with Serializer = Serializer customs }
@@ -100,7 +100,7 @@ let rec toJsonValue cfg (obj: obj) =
                 | [| item |] -> Some item
                 | array -> JsonValue.Array array |> Some
             case.Name, json
-        match FSharpType.GetUnionCases (t, true), cfg.Tag with
+        match FSharpType.GetUnionCases (t, true), cfg.UnionTagging with
         | [| case |], _ when case.Name = t.Name -> // single case union
           json |> Option.defaultValue (JsonValue.String case.Name)
         | _, Some tag ->
@@ -201,7 +201,7 @@ let rec private fromJsonValueByType cfg (t: System.Type) (json: JsonValue) : obj
           | _ -> None)
       |> function Some obj -> obj | _ -> fail ()
     | DesUtil.Union (cases, create), JsonValue.Record fields ->
-      cfg.Tag
+      cfg.UnionTagging
       |> Option.bind (fun tag ->
         let t = fields |> Array.tryFind (fst >> (=) tag.Tag)
         let c = fields |> Array.tryFind (fst >> (=) tag.Content)

--- a/FSharp.JSerde/JSerde.fs
+++ b/FSharp.JSerde/JSerde.fs
@@ -85,12 +85,13 @@ let rec toJsonValue cfg (obj: obj) =
         |> JsonValue.Record
       elif FSharpType.IsUnion (t, bindingFlags) then
         let case, fields = FSharpValue.GetUnionFields (obj, t, true)
-        if (FSharpType.GetUnionCases (t, true)).Length = 1 then // single case union
+        match FSharpType.GetUnionCases (t, true) with
+        | [| case |] when case.Name = t.Name -> // single case union
           match fields with
           | [||] -> JsonValue.String case.Name
           | [| item |] -> toJsonValue cfg item
           | array -> array |> Array.map (toJsonValue cfg) |> JsonValue.Array
-        else
+        | _ ->
           match fields with
           | [||] -> JsonValue.String case.Name
           | [| item |] -> JsonValue.Record [| case.Name, toJsonValue cfg item |]

--- a/FSharp.JSerde/JSerde.fs
+++ b/FSharp.JSerde/JSerde.fs
@@ -9,6 +9,12 @@ let custom<'a> (serialize: 'a -> JsonValue) (deserialize: JsonValue -> 'a) =
       member _.Serialize obj = serialize (obj :?> 'a)
       member _.Deserialize json = deserialize json :> obj }
 
+type Config = {
+  Serializer: Serializer
+} with
+  static member Default = { Serializer = Serializer.Empty }
+  static member FromCustomSerializers customs = { Serializer = Serializer customs }
+
 
 // ------------------------------------------------------------------------
 // serialization
@@ -19,9 +25,9 @@ exception UnsupportedType of System.Type
 let private bindingFlags = System.Reflection.BindingFlags.Public ||| System.Reflection.BindingFlags.NonPublic
 
 /// Serialize F# value into `FSharp.Data.JsonValue`
-let rec toJsonValue (custom : Serializer option) (obj: obj) =
+let rec toJsonValue cfg (obj: obj) =
   if isNull obj then JsonValue.Null else
-  match custom |> Option.bind (fun c -> c.Serialize obj) with
+  match cfg.Serializer.Serialize obj with
   | Some json -> json
   | _ ->
     match obj with
@@ -41,20 +47,20 @@ let rec toJsonValue (custom : Serializer option) (obj: obj) =
     | :? sbyte as value -> JsonValue.Number (decimal value)
     | :? nativeint as value -> JsonValue.Number (decimal value)
     | :? unativeint as value -> JsonValue.Number (decimal value)
-    | :? System.Array as a -> Array.init a.Length (fun i -> a.GetValue i |> toJsonValue custom) |> JsonValue.Array
+    | :? System.Array as a -> Array.init a.Length (fun i -> a.GetValue i |> toJsonValue cfg) |> JsonValue.Array
     | _ ->
       let t = obj.GetType()
       if FSharpType.IsTuple t then
         FSharpValue.GetTupleFields obj
-        |> Array.map (toJsonValue custom)
+        |> Array.map (toJsonValue cfg)
         |> JsonValue.Array
       elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> then
         let case, fields = FSharpValue.GetUnionFields (obj, obj.GetType(), false)
         if case.Name = "Some"
-          then toJsonValue custom fields[0]
+          then toJsonValue cfg fields[0]
           else JsonValue.Null
       elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<list<_>> then
-        serializeList custom obj
+        serializeList cfg obj
         |> List.toArray
         |> JsonValue.Array
       elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Map<_, _>> then
@@ -62,14 +68,14 @@ let rec toJsonValue (custom : Serializer option) (obj: obj) =
         |> Seq.cast<obj>
         |> Seq.map (fun pair ->
           let t = pair.GetType()
-          let get name = (t.GetProperty name).GetValue pair |> toJsonValue custom
+          let get name = (t.GetProperty name).GetValue pair |> toJsonValue cfg
           let key = get "Key" |> function JsonValue.String s -> s | json -> string json
           key, get "Value")
         |> Seq.toArray
         |> JsonValue.Record
       elif FSharpType.IsRecord (t, bindingFlags) then
         FSharpType.GetRecordFields (t, bindingFlags)
-        |> Array.map (fun prop -> prop.Name, FSharpValue.GetRecordField (obj, prop) |> toJsonValue custom)
+        |> Array.map (fun prop -> prop.Name, FSharpValue.GetRecordField (obj, prop) |> toJsonValue cfg)
         |> Array.filter (snd >> (<>) JsonValue.Null)
         |> JsonValue.Record
       elif FSharpType.IsUnion (t, bindingFlags) then
@@ -77,33 +83,33 @@ let rec toJsonValue (custom : Serializer option) (obj: obj) =
         if (FSharpType.GetUnionCases (t, true)).Length = 1 then // single case union
           match fields with
           | [||] -> JsonValue.String case.Name
-          | [| item |] -> toJsonValue custom item
-          | array -> array |> Array.map (toJsonValue custom) |> JsonValue.Array
+          | [| item |] -> toJsonValue cfg item
+          | array -> array |> Array.map (toJsonValue cfg) |> JsonValue.Array
         else
           match fields with
           | [||] -> JsonValue.String case.Name
-          | [| item |] -> JsonValue.Record [| case.Name, toJsonValue custom item |]
-          | array -> JsonValue.Record [| case.Name, array |> Array.map (toJsonValue custom) |> JsonValue.Array |]
+          | [| item |] -> JsonValue.Record [| case.Name, toJsonValue cfg item |]
+          | array -> JsonValue.Record [| case.Name, array |> Array.map (toJsonValue cfg) |> JsonValue.Array |]
       elif t.IsEnum then
         let name = System.Enum.GetName (t, obj)
         if System.String.IsNullOrEmpty name
-          then System.Convert.ChangeType (obj, t.GetEnumUnderlyingType()) |> toJsonValue custom
+          then System.Convert.ChangeType (obj, t.GetEnumUnderlyingType()) |> toJsonValue cfg
           else JsonValue.String name
       elif t.GetMethod ("Parse", [| typeof<string> |]) |> isNull |> not then
         obj.ToString() |> JsonValue.String
       else
         raise (UnsupportedType t)
 
-and private serializeList (custom: Serializer option) obj =
+and private serializeList cfg obj =
   let case, fields = FSharpValue.GetUnionFields (obj, obj.GetType(), false)
   if case.Name = "Cons" then
-    toJsonValue custom fields[0] :: serializeList custom fields[1]
+    toJsonValue cfg fields[0] :: serializeList cfg fields[1]
   else
     []
 
 /// Serialize F# value into JSON string
-let toJsonStringWith fmt custom (obj: obj) =
-  (toJsonValue custom obj).ToString(if fmt then JsonSaveOptions.None else JsonSaveOptions.DisableFormatting)
+let toJsonStringWith fmt cfg (obj: obj) =
+  (toJsonValue cfg obj).ToString(if fmt then JsonSaveOptions.None else JsonSaveOptions.DisableFormatting)
 
 /// Serialize F# value into unformatted JSON string
 let toJsonString: _ -> obj -> _ = toJsonStringWith false
@@ -120,41 +126,41 @@ exception TypeMismatch of Type:System.Type * Json:JsonValue with
   override this.Message =
     sprintf "`%s` doesn't match with %A" this.Type.FullName this.Json
 
-let rec private fromJsonValueByType (custom: Serializer option) (t: System.Type) (json: JsonValue) : obj =
+let rec private fromJsonValueByType cfg (t: System.Type) (json: JsonValue) : obj =
   let fail () = TypeMismatch (t, json) |> raise
-  match custom |> Option.bind (fun c -> c.Deserialize (t, json)) with
+  match cfg.Serializer.Deserialize (t, json) with
   | Some obj -> obj
   | _ ->
     match DesUtil.classify t, json with
     | DesUtil.Array (elmType, createArray), JsonValue.Array src ->
       src
-      |> Array.map (fun obj -> fromJsonValueByType custom elmType obj)
+      |> Array.map (fun obj -> fromJsonValueByType cfg elmType obj)
       |> createArray
     | DesUtil.Option (elmType, createOption), json ->
       if json = JsonValue.Null
         then None
-        else fromJsonValueByType custom elmType json |> Some 
+        else fromJsonValueByType cfg elmType json |> Some 
       |> createOption
     | DesUtil.List (elmType, createList), JsonValue.Array src ->
       src
-      |> Array.map (fromJsonValueByType custom elmType)
+      |> Array.map (fromJsonValueByType cfg elmType)
       |> createList
     | DesUtil.Map (keyType, valueType, createMap), JsonValue.Record src ->
       src
       |> Array.map (fun (key, value) ->
         let key =
           JsonValue.TryParse key
-          |> Option.map (fromJsonValueByType custom keyType)
+          |> Option.map (fromJsonValueByType cfg keyType)
           |> Option.defaultValue key
-        let value = fromJsonValueByType custom valueType value
+        let value = fromJsonValueByType cfg valueType value
         key, value)
       |> createMap
     | DesUtil.SingleCaseUnion (fields, create), json ->
       match fields, json with
-      | [| field |], _ -> create [| fromJsonValueByType custom field.PropertyType json |]
+      | [| field |], _ -> create [| fromJsonValueByType cfg field.PropertyType json |]
       | fields, JsonValue.Array a when fields.Length = a.Length ->
         Array.zip fields a
-        |> Array.map (fun (field, json) -> fromJsonValueByType custom field.PropertyType json)
+        |> Array.map (fun (field, json) -> fromJsonValueByType cfg field.PropertyType json)
         |> create
       | _ -> fail()
     | DesUtil.Union (cases, create), JsonValue.String name ->
@@ -166,10 +172,10 @@ let rec private fromJsonValueByType (custom: Serializer option) (t: System.Type)
       |> Array.tryFind (fun case -> case.Name = name)
       |> Option.bind (fun case ->
           match case.GetFields(), json with
-          | [| field |], _ -> create case [| fromJsonValueByType custom field.PropertyType json |] |> Some
+          | [| field |], _ -> create case [| fromJsonValueByType cfg field.PropertyType json |] |> Some
           | fields, JsonValue.Array a when fields.Length = a.Length -> 
             Array.zip fields a
-            |> Array.map (fun (field, json) -> fromJsonValueByType custom field.PropertyType json)
+            |> Array.map (fun (field, json) -> fromJsonValueByType cfg field.PropertyType json)
             |> create case |> Some
           | _ -> None)
       |> function Some obj -> obj | _ -> fail ()
@@ -179,17 +185,17 @@ let rec private fromJsonValueByType (custom: Serializer option) (t: System.Type)
         src
         |> Array.tryFind (fst >> (=) field.Name)
         |> function Some (_, json) -> json | None -> JsonValue.Null
-        |> fromJsonValueByType custom field.PropertyType)
+        |> fromJsonValueByType cfg field.PropertyType)
       |> create
     | DesUtil.Tuple (elmTypes, create), JsonValue.Array src when src.Length = elmTypes.Length ->
       Array.zip elmTypes src
-      |> Array.map (fun (t, json) -> fromJsonValueByType custom t json)
+      |> Array.map (fun (t, json) -> fromJsonValueByType cfg t json)
       |> create
     | DesUtil.Enum t, _ ->
       let mutable value = null
       match json with
       | JsonValue.String s when System.Enum.TryParse (t, s, &value) -> value
-      | _ -> System.Enum.ToObject (t, fromJsonValueByType custom (t.GetEnumUnderlyingType()) json)
+      | _ -> System.Enum.ToObject (t, fromJsonValueByType cfg (t.GetEnumUnderlyingType()) json)
     | DesUtil.String,   JsonValue.String s -> s :> obj
     | DesUtil.Char,     JsonValue.String s -> s[0] :> obj
     | DesUtil.Bool,     JsonValue.Boolean b -> b :> obj
@@ -223,10 +229,10 @@ let rec private fromJsonValueByType (custom: Serializer option) (t: System.Type)
     | _ -> fail ()
 
 /// Deserialize `FSharp.Data.JsonValue` into F# type
-let fromJsonValue<'a> custom json = fromJsonValueByType custom typeof<'a> json :?> 'a
+let fromJsonValue<'a> cfg json = fromJsonValueByType cfg typeof<'a> json :?> 'a
 
 
 /// Deserialize JSON string into F# type
-let fromJsonString<'a> custom json =
+let fromJsonString<'a> cfg json =
   JsonValue.Parse json
-  |> fromJsonValue<'a> custom
+  |> fromJsonValue<'a> cfg

--- a/FSharp.JSerde/JSerde.fs
+++ b/FSharp.JSerde/JSerde.fs
@@ -11,9 +11,14 @@ let custom<'a> (serialize: 'a -> JsonValue) (deserialize: JsonValue -> 'a) =
 
 type Config = {
   Serializer: Serializer
+  Tag: string option
 } with
-  static member Default = { Serializer = Serializer.Empty }
-  static member FromCustomSerializers customs = { Serializer = Serializer customs }
+  static member Default =
+    { Serializer = Serializer.Empty
+      Tag = None }
+
+  static member FromCustomSerializers customs =
+    { Config.Default with Serializer = Serializer customs }
 
 
 // ------------------------------------------------------------------------
@@ -24,7 +29,7 @@ exception UnsupportedType of System.Type
 
 let private bindingFlags = System.Reflection.BindingFlags.Public ||| System.Reflection.BindingFlags.NonPublic
 
-/// Serialize F# value into `FSharp.Data.JsonValue`
+/// Serialize F# value into <c>FSharp.Data.JsonValue</c>
 let rec toJsonValue cfg (obj: obj) =
   if isNull obj then JsonValue.Null else
   match cfg.Serializer.Serialize obj with
@@ -228,7 +233,7 @@ let rec private fromJsonValueByType cfg (t: System.Type) (json: JsonValue) : obj
     | DesUtil.Parsable parse, JsonValue.String s -> parse s
     | _ -> fail ()
 
-/// Deserialize `FSharp.Data.JsonValue` into F# type
+/// Deserialize <c>FSharp.Data.JsonValue</c> into F# type
 let fromJsonValue<'a> cfg json = fromJsonValueByType cfg typeof<'a> json :?> 'a
 
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ let value = {
     ] 
 }
 
-let json = JSerde.toJsonString None value
+let json = JSerde.toJsonString JSerde.Config.Default value
 printfn "json = %O" json
 
-let parsed = JSerde.fromJsonString<RecordType> None json
+let parsed = JSerde.fromJsonString<RecordType> JSerde.Config.Default json
 printfn "parsed = %A" parsed
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,20 @@ Output:
 ```
 json = {"A":"hello","B":123,"C":{"111":"Case1","222":null,"333":{"Case2":"bye"},"444":{"Case3":{"Bar":true,"Foo":555}}}}
 ```
+
+## Union tagging
+You can configure union type's tagging style by `JSerde.Config`.
+
+```fsharp
+type UnionType =
+    | Case1
+    | Case2 of string
+    | Case3 of {| Foo: int; Bar: bool |}
+
+[<Test>]
+let testUnionTagging () =
+  let json1 = Case2 "hello" |> JSerde.toJsonString JSerde.Config.Default
+  let json2 = Case2 "hello" |> JSerde.toJsonString { JSerde.Config.Default with UnionTagging = Some { Tag = "t"; Content = "c" } }
+  Assert.AreEqual (json1, "{\"Case2\":\"hello\"}")
+  Assert.AreEqual (json2, "{\"t\":\"Case2\",\"c\":\"hello\"}")
+```


### PR DESCRIPTION
* `JSerde.Config` を作成し、第1引数にこれを渡す仕様に変更
* `JSerde.Config` に `UnionTagging` フィールドを追加し、union 型のタグ付きフォーマットを制御できるようにした